### PR TITLE
로비에 있는 버튼의 배경색 제거

### DIFF
--- a/src/main/java/com/miri_and_donghak/makefriend/component/Lobby.java
+++ b/src/main/java/com/miri_and_donghak/makefriend/component/Lobby.java
@@ -71,6 +71,8 @@ public class Lobby extends JFrame {
         buttons.add(makeFriendButton);
         buttons.add(showMyFriendButton);
 
+        buttons.setBackground(new Color(0,0,0,0));
+
         return buttons;
     }
 }


### PR DESCRIPTION
## 🎲 주요 변경 내용
버튼이 들어가있는 패널의 배경색을 투명으로 바꿈으로써 배경 이미지를 잘리지 않게 하였습니다.

## 📚 부가적인 요점

## 🤔 사용방법

## 🎸 기타
